### PR TITLE
Add setup script for easier installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ In order to provide the most appropriate comparisons, RapidMoc calculates model 
 The impact of uncertainties in the geostrophic level of no motion is described further by [Roberts et al. (2013)](http://onlinelibrary.wiley.com/doi/10.1002/grl.50930/full).
 
 ## Using RapidMoc
+
+### Install package
+
+To install the package, run:
+
+```bash
+pip install git+https://github.com:cdr30/RapidMoc.git#egg=RapidMoc
+```
+
+### Install manually
+
 #### Required python libraries
 RapidMoc was developed using Python 2.7 and requires the installation of the following python libraries and their associated dependencies: `numpy`, `netCDF4`, `ConfigParser`, `argparse`, `os`, `matplotlib`, `abc`, `datetime`, `scipy`, `copy`, and `math`. 
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+"""Setup gnomon."""
+
+from setuptools import setup
+
+setup(name='rapidmoc',
+      description='Calculates observational-style decomposition of AMOC using '
+                  'output from an ocean general circulation model.',
+      packages=['rapidmoc'],
+      package_dir={'rapidmoc': 'rapidmoc'},
+      package_data={'rapidmoc': ['etc/*']},
+      install_requires=['setuptools', 'netCDF4', 'numpy',  'matplotlib',
+                        'scipy'],
+      entry_points={
+          'console_scripts':
+          ['run_rapidmoc.py = rapidmoc.rapidmoc:main']},
+      zip_safe=False)

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Setup gnomon."""
+"""Setup RapidMoc."""
 
 from setuptools import setup
 


### PR DESCRIPTION
This is a cleaned-up version of #1.

> To allow for easier installation, this PR adds a setup.py which makes sure all dependencies are present and puts a run_rapidmoc.py into the Path (of the python-env under which rapidmoc is installed). It also adds info to the README to explain how to install with Pip.
> 
> Note that the run_rapidmoc.py that is created is not the file of the same name that's in the repo but an entry point forwarding all stdin to rapidmoc.main(). For my tests, this worked fine. I'm not sure if it catches KeyboardInterrupts in the same way as the original run_rapidmoc.py.